### PR TITLE
Fixed error test when words are in different order

### DIFF
--- a/src/week1/exercise27/mod.rs
+++ b/src/week1/exercise27/mod.rs
@@ -9,9 +9,11 @@ pub fn uncommon_words(a: String, b: String) -> Vec<String> {
         *count += 1;
     }
 
-    all_words
+    let mut all_words = all_words
         .into_iter()
         .filter(|(_, value)| *value == 1)
         .map(|(key, _)| key.to_string())
-        .collect::<Vec<String>>()
+        .collect::<Vec<String>>();
+    all_words.sort();
+    all_words
 }

--- a/tests/week1/exercise27/mod.rs
+++ b/tests/week1/exercise27/mod.rs
@@ -4,7 +4,8 @@ use onboarding_rust::week1::exercise27::uncommon_words;
 fn test_week1_uncommon_words() {
     let input_a = String::from("this apple is sweet");
     let input_b = String::from("this apple is sour");
-    let output = vec!["sweet".to_string(), "sour".to_string()];
+    let mut output = vec!["sweet".to_string(), "sour".to_string()];
+    output.sort();
     assert_eq!(output, uncommon_words(input_a, input_b));
 }
 


### PR DESCRIPTION
- What: Fixed error when result and expected output are in different order.
- Why: Build failed randomly.

## PR - Merge Checklist
- [ ] CR'd
- [ ] Workflow: Trello card is in "Code Review" column
- [ ] README updated or N/A
